### PR TITLE
perf: Sync state back to JS + clear prop registry

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedCommitHook.cpp
@@ -76,10 +76,16 @@ RootShadowNode::Unshared ReanimatedCommitHook::shadowTreeWillCommit(
   {
     auto lock = updatesRegistryManager_->lock();
 
-    PropsMap propsMap = updatesRegistryManager_->collectProps();
+    PropsMap propsMap =
+        updatesRegistryManager_->collectProps(); // Reanimated.View {...props}
     updatesRegistryManager_->cancelCommitAfterPause();
 
-    rootNode = cloneShadowTreeWithNewProps(*rootNode, propsMap);
+    std::vector<Tag> tagsToRemove;
+    rootNode = cloneShadowTreeWithNewProps(*rootNode, propsMap, tagsToRemove);
+    for (const auto& tag : tagsToRemove) {
+        updatesRegistryManager_->markNodeAsImmediateRemovable(tag);
+    }
+
     // If the commit comes from React Native then pause commits from
     // Reanimated since the ShadowTree to be committed by Reanimated may not
     // include the new changes from React Native yet and all changes of animated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ReanimatedMountHook.cpp
@@ -23,6 +23,13 @@ void ReanimatedMountHook::shadowTreeDidMount(
     double) noexcept {
   ReanimatedSystraceSection s("ReanimatedMountHook::shadowTreeDidMount");
 
+  // Nodes marked earlier in ReanimatedCommitHook for removal (if there props were the same) are removed here
+  // because here we know that the commit is finished and we can safely remove
+  {
+    auto lock = updatesRegistryManager_->lock();
+    updatesRegistryManager_->removeImmediateRemovableNodes();
+  }
+
   auto reaShadowNode =
       std::reinterpret_pointer_cast<ReanimatedCommitShadowNode>(
           std::const_pointer_cast<RootShadowNode>(rootShadowNode));

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.cpp
@@ -6,6 +6,29 @@
 
 namespace reanimated {
 
+/**
+ * Checks it the props of a are identical to the props in b.
+ * Doesn't mean they are deeply the same, just that b has everything that a has.
+ */
+bool checkPropsEqual(const folly::dynamic& a, const folly::dynamic& b) {
+    for (const auto& pair : a.items()) {
+        const auto& key = pair.first;
+        auto it = b.find(key);
+        if (it == b.items().end()) {
+            return false; // Key from A not found in B
+        }
+
+        const auto& valueA = pair.second;
+        const auto& valueB = it->second;
+
+        if (valueA != valueB) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 Props::Shared mergeProps(
     const ShadowNode &shadowNode,
     const PropsMap &propsMap,
@@ -46,7 +69,8 @@ Props::Shared mergeProps(
 ShadowNode::Unshared cloneShadowTreeWithNewPropsRecursive(
     const ShadowNode &shadowNode,
     const ChildrenMap &childrenMap,
-    const PropsMap &propsMap) {
+    const PropsMap &propsMap,
+    std::vector<Tag>& tagsToRemove) {
   const auto family = &shadowNode.getFamily();
   const auto affectedChildrenIt = childrenMap.find(family);
   auto children = shadowNode.getChildren();
@@ -54,12 +78,27 @@ ShadowNode::Unshared cloneShadowTreeWithNewPropsRecursive(
   if (affectedChildrenIt != childrenMap.end()) {
     for (const auto index : affectedChildrenIt->second) {
       children[index] = cloneShadowTreeWithNewPropsRecursive(
-          *children[index], childrenMap, propsMap);
+          *children[index], childrenMap, propsMap, tagsToRemove);
     }
   }
 
+  const auto newProps = mergeProps(shadowNode, propsMap, *family);
+
+ if (newProps) {
+     ReanimatedSystraceSection s("ShadowTreeCloner::equalityCheck");
+
+     const auto& shadowNodeProps = shadowNode.getProps()->rawProps;
+     const auto& newPropsDynamic = newProps->rawProps;
+     bool isSame = newPropsDynamic == shadowNodeProps ||
+              checkPropsEqual(newPropsDynamic, shadowNodeProps);
+
+     if (isSame) {
+         tagsToRemove.push_back(shadowNode.getTag());
+     }
+ }
+
   return shadowNode.clone(
-      {mergeProps(shadowNode, propsMap, *family),
+      {newProps,
        std::make_shared<ShadowNode::ListOfShared>(children),
        shadowNode.getState(),
        false});
@@ -67,13 +106,14 @@ ShadowNode::Unshared cloneShadowTreeWithNewPropsRecursive(
 
 RootShadowNode::Unshared cloneShadowTreeWithNewProps(
     const RootShadowNode &oldRootNode,
-    const PropsMap &propsMap) {
+    const PropsMap &propsMap,
+    std::vector<Tag>& tagsToRemove) {
   ReanimatedSystraceSection s("ShadowTreeCloner::cloneShadowTreeWithNewProps");
 
   ChildrenMap childrenMap;
 
   {
-    ReanimatedSystraceSection s("ShadowTreeCloner::prepareChildrenMap");
+    ReanimatedSystraceSection s1("ShadowTreeCloner::prepareChildrenMap");
 
     for (auto &[family, _] : propsMap) {
       const auto ancestors = family->getAncestors(oldRootNode);
@@ -95,7 +135,7 @@ RootShadowNode::Unshared cloneShadowTreeWithNewProps(
   // This cast is safe, because this function returns a clone
   // of the oldRootNode, which is an instance of RootShadowNode
   return std::static_pointer_cast<RootShadowNode>(
-      cloneShadowTreeWithNewPropsRecursive(oldRootNode, childrenMap, propsMap));
+      cloneShadowTreeWithNewPropsRecursive(oldRootNode, childrenMap, propsMap, tagsToRemove));
 }
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/ShadowTreeCloner.h
@@ -14,6 +14,11 @@ using namespace react;
 
 namespace reanimated {
 
+struct CloneResult {
+    RootShadowNode::Unshared newRoot;
+    std::vector<Tag> tagsToRemove;
+};
+
 using PropsMap =
     std::unordered_map<const ShadowNodeFamily *, std::vector<RawProps>>;
 using ChildrenMap =
@@ -21,6 +26,7 @@ using ChildrenMap =
 
 RootShadowNode::Unshared cloneShadowTreeWithNewProps(
     const RootShadowNode &oldRootNode,
-    const PropsMap &propsMap);
+    const PropsMap &propsMap,
+    std::vector<Tag>& tagsToRemove);
 
 } // namespace reanimated

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.cpp
@@ -74,6 +74,24 @@ void UpdatesRegistryManager::handleNodeRemovals(
   }
 }
 
+void UpdatesRegistryManager::markNodeAsImmediateRemovable(Tag tag) {
+  immediateRemovableShadowNodes_.emplace(tag);
+}
+
+void UpdatesRegistryManager::unmarkNodeAsImmediateRemovable(Tag tag) {
+  immediateRemovableShadowNodes_.erase(tag);
+}
+
+void UpdatesRegistryManager::removeImmediateRemovableNodes() {
+  for (auto& tag : immediateRemovableShadowNodes_) {
+      for (auto &registry : registries_) {
+          registry->remove(tag);
+      }
+      staticPropsRegistry_->remove(tag);
+  }
+  immediateRemovableShadowNodes_.clear();
+}
+
 PropsMap UpdatesRegistryManager::collectProps() {
   PropsMap propsMap;
   for (auto &registry : registries_) {

--- a/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.h
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/Fabric/updates/UpdatesRegistryManager.h
@@ -32,6 +32,11 @@ class UpdatesRegistryManager {
   bool shouldCommitAfterPause();
   void cancelCommitAfterPause();
 
+ // Custom discord added for removing nodes once they seem in sync with the shadow tree
+ void markNodeAsImmediateRemovable(Tag tag);
+ void unmarkNodeAsImmediateRemovable(Tag viewTag);
+ void removeImmediateRemovableNodes();
+
   void markNodeAsRemovable(const ShadowNode::Shared &shadowNode);
   void unmarkNodeAsRemovable(Tag viewTag);
   void handleNodeRemovals(const RootShadowNode &rootShadowNode);
@@ -49,6 +54,7 @@ class UpdatesRegistryManager {
   std::atomic<bool> isPaused_;
   std::atomic<bool> shouldCommitAfterPause_;
   std::unordered_map<Tag, ShadowNode::Shared> removableShadowNodes_;
+  std::unordered_set<Tag> immediateRemovableShadowNodes_;
   std::vector<std::shared_ptr<UpdatesRegistry>> registries_;
   const std::shared_ptr<StaticPropsRegistry> staticPropsRegistry_;
 

--- a/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
+++ b/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp
@@ -809,8 +809,10 @@ void ReanimatedModuleProxy::commitUpdates(
               return nullptr;
             }
 
+            // TODO: we don't really need the list here, make it optional?
+            std::vector<Tag> list;
             auto rootNode =
-                cloneShadowTreeWithNewProps(oldRootShadowNode, propsMap);
+                cloneShadowTreeWithNewProps(oldRootShadowNode, propsMap, list);
 
             // Mark the commit as Reanimated commit so that we can distinguish
             // it in ReanimatedCommitHook.

--- a/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/AnimatedComponent.tsx
@@ -2,6 +2,7 @@
 import '../layoutReanimation/animationsManager';
 
 import type React from 'react';
+import { StyleSheet } from 'react-native';
 
 import { getReduceMotionFromConfig } from '../animation/util';
 import { maybeBuild } from '../animationBuilder';
@@ -34,6 +35,7 @@ import type {
   InitialComponentProps,
   NestedArray,
 } from './commonTypes';
+import { ComponentRegistry } from './ComponentRegistry';
 import { InlinePropManager } from './InlinePropManager';
 import JSPropsUpdater from './JSPropsUpdater';
 import { NativeEventsManager } from './NativeEventsManager';
@@ -52,7 +54,8 @@ export type Options<P> = {
 
 export default class AnimatedComponent
   extends ReanimatedAnimatedComponent<
-    AnimatedComponentProps<InitialComponentProps>
+    AnimatedComponentProps<InitialComponentProps>,
+    { styleProps: StyleProps }
   >
   implements IAnimatedComponentInternal
 {
@@ -88,6 +91,10 @@ export default class AnimatedComponent
       this.jestAnimatedProps = { value: {} };
     }
 
+    this.state = {
+      styleProps: {},
+    };
+
     const entering = this.props.entering;
     const skipEntering = this.context?.current;
     if (
@@ -115,6 +122,11 @@ export default class AnimatedComponent
     this._jsPropsUpdater.addOnJSPropsChangeListener(this);
     this._attachAnimatedStyles();
     this._InlinePropManager.attachInlineProps(this, this._getViewInfo());
+
+    const viewTag = this.getComponentViewTag();
+    if (viewTag !== -1) {
+      ComponentRegistry.register(viewTag, this);
+    }
 
     const layout = this.props.layout;
     if (layout) {
@@ -159,6 +171,11 @@ export default class AnimatedComponent
 
     const exiting = this.props.exiting;
 
+    const viewTag = this.getComponentViewTag();
+    if (viewTag !== -1) {
+      ComponentRegistry.unregister(viewTag);
+    }
+
     if (
       IS_WEB &&
       this._componentDOMRef &&
@@ -173,6 +190,15 @@ export default class AnimatedComponent
         LayoutAnimationType.EXITING
       );
     }
+  }
+
+  /**
+   * Mechanism to update this component's props from native. (As reanimated is
+   * changing the props only on the UI thread at some point we want to sync
+   * with the JS thread).
+   */
+  _updateStylePropsJS(props: StyleProps) {
+    this.setState({ styleProps: props });
   }
 
   _detachStyles() {
@@ -417,9 +443,16 @@ export default class AnimatedComponent
         }
       : {};
 
+    const flatStyles = StyleSheet.flatten(filteredProps.style as object);
+    const mergedStyles = {
+      ...flatStyles,
+      ...this.state.styleProps,
+    };
+
     return super.render({
       nativeID,
       ...filteredProps,
+      style: mergedStyles,
       ...jestProps,
     });
   }

--- a/packages/react-native-reanimated/src/createAnimatedComponent/ComponentRegistry.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/ComponentRegistry.ts
@@ -1,0 +1,29 @@
+import type { IAnimatedComponentInternal } from '../createAnimatedComponent/commonTypes';
+
+// Registry to map component tags to component instances
+const componentRegistry = new Map<
+  number | HTMLElement,
+  IAnimatedComponentInternal
+>();
+
+export const ComponentRegistry = {
+  // Register a component instance with its tag
+  register: (
+    tag: number | HTMLElement,
+    component: IAnimatedComponentInternal
+  ) => {
+    componentRegistry.set(tag, component);
+  },
+
+  // Unregister a component
+  unregister: (tag: number | HTMLElement) => {
+    componentRegistry.delete(tag);
+  },
+
+  // Get a component for a tag
+  getComponent: (
+    tag: number | HTMLElement
+  ): IAnimatedComponentInternal | undefined => {
+    return componentRegistry.get(tag);
+  },
+};

--- a/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
+++ b/packages/react-native-reanimated/src/createAnimatedComponent/commonTypes.ts
@@ -121,6 +121,12 @@ export interface IAnimatedComponentInternal {
    * handling.
    */
   getComponentViewTag: () => number;
+
+  /**
+   * A function that will update the components state (the state is used for the
+   * style prop)
+   */
+  _updateStylePropsJS: (props: StyleProps) => void;
 }
 
 export type NestedArray<T> = T | NestedArray<T>[];

--- a/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
+++ b/packages/react-native-reanimated/src/css/component/AnimatedComponent.tsx
@@ -28,7 +28,8 @@ export type AnimatedComponentProps = Record<string, unknown> & {
 // to the main one)
 export default class AnimatedComponent<
   P extends AnyRecord = AnimatedComponentProps,
-> extends Component<P> {
+  S extends AnyRecord = Record<string, unknown>,
+> extends Component<P, S> {
   ChildComponent: AnyComponent;
 
   _CSSManager?: CSSManager;

--- a/packages/react-native-reanimated/src/privateGlobals.d.ts
+++ b/packages/react-native-reanimated/src/privateGlobals.d.ts
@@ -103,4 +103,8 @@ declare global {
     nativeStateSource?: object
   ) => FlatShareableRef<T>;
   var ReanimatedError: IReanimatedErrorConstructor;
+
+  // On UI Thread:
+  var __lastUpdateFrameTimeByTag: Record<number, number | undefined>;
+  var __lastUpdateByTag: Record<number, StyleProps | undefined>;
 }

--- a/packages/react-native-reanimated/src/updateProps/updateProps.ts
+++ b/packages/react-native-reanimated/src/updateProps/updateProps.ts
@@ -2,7 +2,7 @@
 'use strict';
 
 import type { MutableRefObject } from 'react';
-import { runOnUI } from 'react-native-worklets';
+import { runOnJS, runOnUI } from 'react-native-worklets';
 
 import {
   IS_JEST,
@@ -16,6 +16,7 @@ import type {
   ShadowNodeWrapper,
   StyleProps,
 } from '../commonTypes';
+import { ComponentRegistry } from '../createAnimatedComponent/ComponentRegistry';
 import type { Descriptor } from '../hook/commonTypes';
 import type { ReanimatedHTMLElement } from '../ReanimatedModule/js-reanimated';
 import { _updatePropsJS } from '../ReanimatedModule/js-reanimated';
@@ -37,6 +38,21 @@ if (SHOULD_BE_USE_WEB) {
 } else {
   updateProps = (viewDescriptors, updates) => {
     'worklet';
+
+    // Important: store the updates before running processing on them
+    // the goal is to use these updates later on react JS to set these as style state to the components.
+    // processing is alternating the style props as RN expects them.
+    viewDescriptors.value.forEach((viewDescriptor) => {
+      const prevState =
+        global.__lastUpdateByTag[viewDescriptor.tag as number] ?? {};
+      global.__lastUpdateByTag[viewDescriptor.tag as number] = {
+        ...prevState, // its important to preserve previous state. When multiple style props are animated they might not all appear in one update.
+        ...updates, // copy updates as process mutates inline
+      };
+      global.__lastUpdateFrameTimeByTag[viewDescriptor.tag as number] =
+        global.__frameTimestamp;
+    });
+
     processColorsInProps(updates);
     if ('transformOrigin' in updates) {
       updates.transformOrigin = processTransformOrigin(updates.transformOrigin);
@@ -64,21 +80,64 @@ export const updatePropsJestWrapper = (
 
 export default updateProps;
 
+function updateJSProps(tag: number, props: StyleProps) {
+  const component = ComponentRegistry.getComponent(tag);
+  if (component) {
+    component._updateStylePropsJS(props);
+  }
+}
+
 function createUpdatePropsManager() {
   'worklet';
   const operations: {
     shadowNodeWrapper: ShadowNodeWrapper;
     updates: StyleProps | AnimatedStyle<any>;
+    tag: number;
   }[] = [];
+
+  const scheduledFrameIds: Record<number, number | undefined> = {};
+
+  function checkUpdate(tag: number) {
+    'worklet';
+
+    const currentFrameTime = global.__frameTimestamp;
+    const lastUpdateFrameTime = global.__lastUpdateFrameTimeByTag[tag];
+    if (!currentFrameTime || !lastUpdateFrameTime) {
+      return;
+    }
+
+    const update = global.__lastUpdateByTag[tag];
+    if (update && currentFrameTime - lastUpdateFrameTime >= 20) {
+      // ~ 2x frames
+      // Animation appears to have settled - update component props on JS
+      runOnJS(updateJSProps)(tag, update);
+      global.__lastUpdateByTag[tag] = undefined;
+      return;
+    }
+
+    if (scheduledFrameIds[tag]) {
+      // Note: REA/Worklets doesn't support cancelAnimationFrame
+      return;
+    }
+
+    scheduledFrameIds[tag] = requestAnimationFrame(() => {
+      'worklet';
+      scheduledFrameIds[tag] = undefined;
+      checkUpdate(tag);
+    });
+  }
+
   return {
     update(
       viewDescriptors: ViewDescriptorsWrapper,
       updates: StyleProps | AnimatedStyle<any>
     ) {
       viewDescriptors.value.forEach((viewDescriptor) => {
+        const tag = viewDescriptor.tag as number; // on mobile it should be a number
         operations.push({
           shadowNodeWrapper: viewDescriptor.shadowNodeWrapper,
           updates,
+          tag,
         });
         if (operations.length === 1) {
           queueMicrotask(this.flush);
@@ -87,6 +146,10 @@ function createUpdatePropsManager() {
     },
     flush(this: void) {
       global._updateProps!(operations);
+      operations.forEach(({ tag }) => {
+        'worklet';
+        checkUpdate(tag);
+      });
       operations.length = 0;
     },
   };

--- a/packages/react-native-worklets/src/initializers.ts
+++ b/packages/react-native-worklets/src/initializers.ts
@@ -173,6 +173,14 @@ export function initializeUIRuntime(WorkletsModule: IWorkletsModule) {
       setupConsole();
       setupMicrotasks();
       setupRequestAnimationFrame();
+
+      // TODO: this needs to move to the reanimated package, but idk where
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      globalThis.__lastUpdateFrameTimeByTag = {};
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      globalThis.__lastUpdateByTag = {};
     })();
   }
 }


### PR DESCRIPTION
This PoC commit shows an example for syncing our state from the UI state back to JS. This enables us to remove nodes from the prop registry. This in turn is a performance improvement as for nodes that are not animating right now we don't need to necessarily clone those

## Summary

## Test plan
